### PR TITLE
chore: bump version to 0.6.0 and add milestone workflow instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,11 @@ ScopeNode (Managed / User / Project Shared / Project Local)
 
 Tree items use `contextValue` strings for menu visibility. Pattern: `{nodeType}.{editable|readOnly}[.overridden]`. Example: `permissionRule.editable` enables edit/delete/move context menu items. Regex matching in `package.json` `when` clauses controls which commands appear.
 
+## Milestone Workflow
+
+- **Always update `CHANGELOG.md`** at the end of each milestone, before archiving. Follow [Keep a Changelog](https://keepachangelog.com) format with Added/Changed/Removed/Fixed sections.
+- **Always bump `version` in `package.json`** to match the milestone version at the end of each milestone.
+
 ## Conventions
 
 - **TypeScript strict mode** — no implicit any, strict null checks

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-code-config-manager",
   "displayName": "Claude Code Config Manager",
   "description": "Visual config viewer and editor for Claude Code settings — scope-aware TreeView with override detection, inline editing, and file watching.",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "publisher": "agnislav",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump `package.json` version from 0.5.1 to 0.6.0 (missed during v0.6.0 milestone)
- Add "Milestone Workflow" section to CLAUDE.md: always update CHANGELOG and bump version at end of each milestone

## Test plan
- [ ] Verify version in package.json is 0.6.0
- [ ] Verify CLAUDE.md has Milestone Workflow section