### PR TITLE
feat(tree): reveal-only-if-open + double-click opens file (#20, #23)

### DIFF
--- a/.claude/epics/terminal-add-permission/16.md
+++ b/.claude/epics/terminal-add-permission/16.md
@@ -1,0 +1,65 @@
+---
+name: Refactor pickers + add portable helpers
+status: open
+created: 2026-04-27T17:47:04Z
+updated: 2026-04-27T17:54:26Z
+github: https://github.com/agnislav/claude-code-config-manager/issues/16
+depends_on: []
+parallel: true
+conflicts_with: []
+---
+
+# Task: Refactor pickers + add portable helpers
+
+## Description
+
+Extract the three permission-flow UI prompts that currently live inline in `src/commands/addCommands.ts` into a dedicated module, and append two portable string-transform helpers to `src/utils/permissions.ts`. This refactor unblocks Task 2 (the terminal-selection command needs to call the same pickers) and lays groundwork for the future lib/CLI extraction by keeping pure logic separated from `vscode`-coupled UI.
+
+The behavior of the existing `claudeConfig.addPermissionRule` command must be unchanged from a user's perspective — the test suite for that flow must pass without modification.
+
+## Acceptance Criteria
+
+- [ ] New file `src/commands/permissionPickers.ts` exports `pickScopeFilePath`, `pickPermissionCategory`, `promptPermissionRuleInput` (the latter accepting an optional pre-filled value).
+- [ ] `src/commands/addCommands.ts` no longer contains the inline picker logic; the existing `claudeConfig.addPermissionRule` handler imports and calls the extracted functions.
+- [ ] `src/utils/permissions.ts` exports `wrapAsBashRule(raw: string): string` (returns `Bash(<raw>:*)`).
+- [ ] `src/utils/permissions.ts` exports `validateSingleLineSelection(raw: string): boolean` (returns `false` when the input contains `\n` or `\r`, `true` otherwise; trims surrounding whitespace before evaluating).
+- [ ] Neither `wrapAsBashRule` nor `validateSingleLineSelection` imports from `vscode` — verified by `grep -L "from 'vscode'" src/utils/permissions.ts` returning the file.
+- [ ] Unit tests cover both new pure helpers (happy path + edge cases: empty string, multi-line, leading/trailing whitespace, embedded special chars).
+- [ ] The existing `claudeConfig.addPermissionRule` test suite passes unchanged.
+- [ ] `npm run typecheck`, `npm run lint`, `npm run test` all pass.
+
+## Technical Details
+
+**Files modified:**
+- `src/commands/addCommands.ts` — remove inline picker logic (currently around lines 34–48 and 314–335 per the epic), replace with imports from `permissionPickers.ts`.
+- `src/utils/permissions.ts` — append `wrapAsBashRule`, `validateSingleLineSelection`.
+
+**Files created:**
+- `src/commands/permissionPickers.ts` — exports the three pickers.
+- Tests for the new helpers (placed alongside existing `permissions` tests).
+
+**Picker signatures (preserve existing return shapes from `addCommands.ts`):**
+- `pickScopeFilePath()` — QuickPick of available scope file paths; returns the chosen path or `undefined` on cancel.
+- `pickPermissionCategory()` — QuickPick over `PermissionCategory` enum; returns the chosen category or `undefined` on cancel.
+- `promptPermissionRuleInput(prefilled?: string)` — InputBox; when `prefilled` is provided, the entire string is pre-selected so Enter accepts verbatim. Returns the entered string or `undefined` on cancel.
+
+**Helper signatures:**
+- `wrapAsBashRule(raw: string): string` — returns `` `Bash(${raw}:*)` ``. No `vscode` import.
+- `validateSingleLineSelection(raw: string): boolean` — `false` if `raw.includes('\n') || raw.includes('\r')`. Trim before checking.
+
+## Dependencies
+
+- None (this is the foundation task).
+
+## Effort Estimate
+
+- Size: S
+- Hours: 3
+
+## Definition of Done
+
+- [ ] Code implemented
+- [ ] Tests written and passing
+- [ ] Existing add-permission test suite passes unchanged
+- [ ] `npm run typecheck`, `npm run lint`, `npm run test` all green
+- [ ] Code reviewed

--- a/.claude/epics/terminal-add-permission/17.md
+++ b/.claude/epics/terminal-add-permission/17.md
@@ -1,0 +1,95 @@
+---
+name: Implement claudeConfig.addPermissionFromTerminalSelection
+status: open
+created: 2026-04-27T17:47:04Z
+updated: 2026-04-27T17:54:26Z
+github: https://github.com/agnislav/claude-code-config-manager/issues/17
+depends_on: ["16"]
+parallel: false
+conflicts_with: []
+---
+
+# Task: Implement claudeConfig.addPermissionFromTerminalSelection
+
+## Description
+
+Add a new VS Code command `claudeConfig.addPermissionFromTerminalSelection` that captures the active terminal selection via the `copy → read → restore` clipboard pattern, validates it, pre-fills `Bash(<selection>:*)` in an editable InputBox, and reuses the existing scope → category → write pipeline. Surface it in the integrated terminal's right-click menu and the command palette under category `Claude Config`.
+
+This is the user-facing feature. Bundled as one task because partial states (a registered command without its menu entry, or a menu without a handler) ship nothing usable.
+
+## Acceptance Criteria
+
+- [ ] New file `src/utils/terminal.ts` exports `captureTerminalSelection(): Promise<string | undefined>` that:
+  - Saves current clipboard contents.
+  - Executes `vscode.commands.executeCommand('workbench.action.terminal.copySelection')`.
+  - Reads the new clipboard text.
+  - Restores the original clipboard contents in a `finally` block (must run on both success and exception paths).
+  - Returns the captured selection (or `undefined` if no selection / nothing copied).
+- [ ] Unit test simulates an exception thrown mid-sequence and asserts the original clipboard contents are restored.
+- [ ] Unit test for the success path also asserts the original clipboard contents are restored after the function returns.
+- [ ] New file `src/commands/terminalSelectionCommands.ts` exports `registerTerminalSelectionCommands(context: vscode.ExtensionContext)` which registers the new command. Handler flow:
+  1. `captureTerminalSelection()`
+  2. If empty/undefined → show rejection toast (FR1 spec) and return.
+  3. `validateSingleLineSelection(captured)` → if false, show multi-line rejection toast and return.
+  4. `wrapAsBashRule(captured)` to build the pre-fill.
+  5. `pickScopeFilePath()` (cancel → return).
+  6. `pickPermissionCategory()` (cancel → return).
+  7. `promptPermissionRuleInput(prefilled)` (cancel → return).
+  8. `withWriteRetry(() => addPermissionRule(...))` to persist.
+- [ ] `src/extension.ts` calls `registerTerminalSelectionCommands(context)` during `activate`.
+- [ ] `src/constants.ts` extended with new label/string constants:
+  - Terminal context menu title.
+  - Command palette title (under `Claude Config` category).
+  - "No selection" rejection toast.
+  - "Multi-line selection not supported" rejection toast.
+  - InputBox prompt label.
+- [ ] `package.json` extended with:
+  - New command contribution: `claudeConfig.addPermissionFromTerminalSelection`.
+  - Entry under `contributes.menus."terminal/context"` (no `when` clause based on selection state — handler validates).
+  - Entry under `contributes.menus.commandPalette` so the palette form is gated separately.
+- [ ] Manual verification path passes: select `git status` in integrated terminal → right-click → choose menu item → pick `Project Shared` + `Allow` → press Enter on pre-filled `Bash(git status:*)` → rule appears in `.claude/settings.json` in ≤ 5 user actions.
+- [ ] Running the palette command with no terminal selection shows the rejection toast and writes nothing.
+- [ ] Multi-line selection (containing `\n` or `\r`) triggers the rejection toast and aborts cleanly.
+- [ ] After running the flow with arbitrary clipboard contents, `vscode.env.clipboard.readText()` returns the original contents (covered by tests in this task).
+- [ ] `npm run typecheck`, `npm run lint`, `npm run test`, `npm run package` all pass.
+
+## Technical Details
+
+**Files created:**
+- `src/utils/terminal.ts`
+- `src/commands/terminalSelectionCommands.ts`
+- Tests for `captureTerminalSelection` (success path + exception path).
+
+**Files modified:**
+- `src/constants.ts` — append the user-facing strings.
+- `src/extension.ts` — call `registerTerminalSelectionCommands`.
+- `package.json` — add the command, terminal context menu entry, and command palette entry.
+
+**Reused unchanged:**
+- `addPermissionRule()` in `src/config/configWriter.ts`.
+- `withWriteRetry()` in `src/utils/commandHelpers.ts`.
+- `PermissionCategory` enum in `src/types.ts`.
+- `SCOPE_LABELS` in `src/constants.ts`.
+- The pickers (`pickScopeFilePath`, `pickPermissionCategory`, `promptPermissionRuleInput`) extracted in Task 1.
+- `wrapAsBashRule`, `validateSingleLineSelection` from Task 1.
+
+**Clipboard restoration is a hard invariant.** Implement as `try/finally` around the copy/read sequence — not best-effort error handling. The exception-path test is non-negotiable.
+
+**Menu always visible.** Per FR1, the `terminal/context` contribution has no `when` clause that depends on selection state. Selection emptiness is handled by the handler, which shows a clear toast.
+
+## Dependencies
+
+- Task 001 (refactored pickers + portable helpers must exist).
+
+## Effort Estimate
+
+- Size: M
+- Hours: 5
+
+## Definition of Done
+
+- [ ] Code implemented
+- [ ] Tests written and passing (including the exception-path clipboard-restore test)
+- [ ] Manual verification via Extension Development Host (F5)
+- [ ] `npm run typecheck`, `npm run lint`, `npm run test`, `npm run package` all green
+- [ ] Code reviewed

--- a/.claude/epics/terminal-add-permission/18.md
+++ b/.claude/epics/terminal-add-permission/18.md
@@ -1,0 +1,48 @@
+---
+name: Docs
+status: open
+created: 2026-04-27T17:47:04Z
+updated: 2026-04-27T17:54:26Z
+github: https://github.com/agnislav/claude-code-config-manager/issues/18
+depends_on: ["17"]
+parallel: false
+conflicts_with: []
+---
+
+# Task: Docs
+
+## Description
+
+Document the new "Add Selection as Permission" terminal flow once Task 2 has shipped. Three small surfaces: the changelog, the README, and the in-repo features context doc.
+
+## Acceptance Criteria
+
+- [ ] `CHANGELOG.md` has a new `### Added` entry under the current `## [Unreleased]` (or appropriate next version) section that names the new command and notes both the terminal-context-menu and command-palette surfaces.
+- [ ] `README.md` includes a short paragraph (≤ 1 paragraph + screenshot placeholder marker) describing the right-click flow: select → right-click → choose menu item → pick scope + category → confirm pre-filled rule.
+- [ ] `.claude/context/features.md` has an appended bullet/paragraph under the permissions section referencing the new command.
+- [ ] No code changes in this task — docs only.
+- [ ] `npm run typecheck`, `npm run lint`, `npm run test` still pass (sanity check; should be unaffected).
+
+## Technical Details
+
+**Files modified:**
+- `CHANGELOG.md` — `### Added` bullet under `## [Unreleased]` (Keep a Changelog format per project conventions).
+- `README.md` — short paragraph in the existing user-facing features area; include a `<!-- screenshot: ... -->` placeholder so a future contributor knows where the screenshot goes.
+- `.claude/context/features.md` — append under the permissions section.
+
+Pull copy and command name verbatim from the Task 2 diff so labels match exactly. Avoid reintroducing implementation detail in user-facing docs — focus on what the user does and sees.
+
+## Dependencies
+
+- Task 002 (the feature must be merged so docs describe what actually shipped, with final command title and toast strings).
+
+## Effort Estimate
+
+- Size: XS
+- Hours: 1
+
+## Definition of Done
+
+- [ ] Docs written
+- [ ] Strings match the shipped command title and toasts exactly
+- [ ] Code reviewed

--- a/.claude/epics/terminal-add-permission/epic.md
+++ b/.claude/epics/terminal-add-permission/epic.md
@@ -1,0 +1,141 @@
+---
+name: terminal-add-permission
+status: backlog
+created: 2026-04-27T17:37:18Z
+updated: 2026-04-27T17:54:26Z
+progress: 0%
+prd: .claude/prds/terminal-add-permission.md
+github: https://github.com/agnislav/claude-code-config-manager/issues/15
+---
+
+# Epic: terminal-add-permission
+
+## Overview
+
+Add a second triggering surface for the existing `claudeConfig.addPermissionRule` flow: a right-click item in the integrated terminal's context menu (and a sibling command-palette entry) that captures the active selection via the clipboard `copy → read → restore` pattern, pre-fills it as `Bash(<selection>:*)` in an editable InputBox, then runs the existing scope → category → write pipeline unchanged.
+
+This is ~80–120 lines of new code plus a small refactor to export the pickers that are currently inline in `addCommands.ts`. No new write paths, no new validators, no new dependencies.
+
+## Architecture Decisions
+
+1. **Reuse, don't rebuild.** The new command delegates to the existing `addPermissionRule()` writer wrapped in `withWriteRetry()`. The only new logic is selection capture and rule pre-fill.
+
+2. **Code placement is governed by the future lib/CLI extraction.** Pure functions with no `vscode` import are *portable* and belong in domain modules that a future lib + CLI will lift wholesale. VS Code-specific code (UI surfaces, command APIs) stays in `src/commands/` or a clearly-marked `src/utils/terminal.ts`. Concretely:
+   - `wrapAsBashRule` and `validateSingleLineSelection` → **`src/utils/permissions.ts`** alongside `parsePermissionRule` / `formatPermissionRule`. They're string transforms; a CLI rejecting multi-line input from stdin would use the exact same code.
+   - `captureTerminalSelection` → **`src/utils/terminal.ts`** (new). Imports `vscode`; not portable. A CLI doesn't have a "terminal selection" concept — its equivalent is `process.argv` / stdin, which never reaches this helper.
+   - Pickers and the InputBox prompt → **`src/commands/permissionPickers.ts`** (new). VS Code QuickPick/InputBox; a CLI would use inquirer or similar.
+
+3. **Extract pickers as a precondition.** `pickScopeFilePath`, the category quick-pick, and the rule InputBox prompt are file-scoped inside `src/commands/addCommands.ts` today (lines 34–48 and 314–335). The PRD's Constraints section explicitly allows extracting them. This is the minimal refactor that makes reuse possible — and it pays compound interest: every future "add permission from <somewhere else>" surface (editor context menu, status bar, code action) becomes a one-handler addition.
+
+4. **Always-visible menu item; handler validates.** Per FR1, the `terminal/context` contribution has no `when` clause that depends on selection state. The handler shows a clear toast if there's no selection. This avoids relying on `terminalSelection` activation context, which is unreliable across terminal frontends.
+
+5. **Clipboard restoration is a hard invariant.** The success criterion "after running the flow with arbitrary clipboard contents, the user's clipboard contents are unchanged" is enforced by a `try/finally` block in `captureTerminalSelection`, not best-effort error handling. This is what the dedicated test in Task 2 verifies.
+
+## Technical Approach
+
+### VS Code surfaces (presentation)
+
+- **Terminal context menu** — new entry in `package.json` under `contributes.menus."terminal/context"`. First time this project declares this menu group.
+- **Command palette** — new entry under category `Claude Config`, title `Add Selection as Permission…`, gated through `contributes.menus.commandPalette`.
+- **InputBox** — pre-filled `Bash(<selection>:*)` with the entire string selected so Enter accepts verbatim or typing overwrites.
+- **All user-facing strings** centralized in `src/constants.ts` for grep-ability.
+
+### Modules
+
+| File | Status | Purpose | Portable? |
+|---|---|---|---|
+| `src/utils/permissions.ts` | extended | + `wrapAsBashRule`, `validateSingleLineSelection` | ✅ yes |
+| `src/utils/terminal.ts` | new | `captureTerminalSelection` (clipboard save/copy/read/restore in try/finally) | ❌ vscode only |
+| `src/commands/permissionPickers.ts` | new | `pickScopeFilePath`, `pickPermissionCategory`, `promptPermissionRuleInput` extracted from `addCommands.ts` | ❌ vscode only |
+| `src/commands/terminalSelectionCommands.ts` | new | `registerTerminalSelectionCommands`; handler wires capture → validate → wrap → pickers → writer | ❌ vscode only |
+| `src/commands/addCommands.ts` | refactored | calls extracted pickers; behavior unchanged | n/a |
+| `src/constants.ts` | extended | menu title, palette title, rejection toast, InputBox prompt | n/a |
+| `src/extension.ts` | extended | registers `registerTerminalSelectionCommands` | n/a |
+| `package.json` | extended | command + `terminal/context` menu + `commandPalette` entries | n/a |
+
+### Reused unchanged
+- `addPermissionRule()` writer in `src/config/configWriter.ts`
+- `withWriteRetry()` in `src/utils/commandHelpers.ts`
+- `PermissionCategory` enum in `src/types.ts`
+- `SCOPE_LABELS` in `src/constants.ts`
+
+## Implementation Strategy
+
+Sequenced by risk-isolation: refactor first (no user-visible change, but touches an existing flow), feature second (new code, no risk to existing flow), docs last.
+
+**Phase 1 — Refactor + portable helpers.**
+Extract pickers into `permissionPickers.ts`. Append `wrapAsBashRule` and `validateSingleLineSelection` to `permissions.ts`. Re-wire `claudeConfig.addPermissionRule` to call the extracted pickers. Existing test suite must pass unchanged. This phase is shippable on its own.
+
+**Phase 2 — New command end-to-end.**
+Build `terminal.ts` (clipboard capture with explicit exception-path test for the restore invariant), the handler in `terminalSelectionCommands.ts`, the `package.json` contributions, the constants, and register in `extension.ts`. All in one task because partial states are broken (a registered command without its menu entry, or a menu entry without its handler, ships nothing usable).
+
+**Phase 3 — Docs.**
+CHANGELOG entry, README paragraph, `.claude/context/features.md` append. Can be drafted from the merged Phase 2 diff.
+
+## Task Breakdown Preview
+
+3 tasks. Each is a meaningful, independently-shippable unit.
+
+1. **Refactor pickers + add portable helpers.**
+   - Move `pickScopeFilePath`, the category quick-pick, and the rule InputBox prompt out of `addCommands.ts` into a new `src/commands/permissionPickers.ts`. Re-wire `claudeConfig.addPermissionRule` to call them.
+   - Append `wrapAsBashRule(raw)` and `validateSingleLineSelection(raw)` to `src/utils/permissions.ts` (no `vscode` import).
+   - Unit tests for both new pure helpers.
+   - Existing add-permission test suite passes unchanged.
+
+2. **Implement `claudeConfig.addPermissionFromTerminalSelection`.**
+   - New `src/utils/terminal.ts` with `captureTerminalSelection` — clipboard save/copy/read/restore wrapped in `try/finally`. Includes a unit test that simulates an exception mid-sequence and asserts the clipboard is restored.
+   - New `src/commands/terminalSelectionCommands.ts` with the handler: capture → `validateSingleLineSelection` → `wrapAsBashRule` → `pickScopeFilePath` → `pickPermissionCategory` → `promptPermissionRuleInput(prefilled)` → `withWriteRetry(addPermissionRule)`.
+   - Append label constants to `src/constants.ts`.
+   - Add the command, the `terminal/context` menu entry, and the `commandPalette` entry to `package.json`.
+   - Register `registerTerminalSelectionCommands` in `src/extension.ts`.
+
+3. **Docs.**
+   - `CHANGELOG.md` `### Added` entry under `## [Unreleased]`.
+   - `README.md` short paragraph (1 paragraph + screenshot placeholder) demonstrating the right-click flow.
+   - `.claude/context/features.md` append under the permissions section.
+
+## Dependencies
+
+### Internal (must exist / be respected)
+- `src/commands/addCommands.ts` — refactor target (Task 1).
+- `src/config/configWriter.ts` — `addPermissionRule()` reused unchanged.
+- `src/utils/commandHelpers.ts` — `withWriteRetry()` reused unchanged.
+- `src/types.ts` — `PermissionCategory` enum.
+- `src/utils/permissions.ts` — host for the new portable helpers.
+- `src/constants.ts` — `SCOPE_LABELS` already exists; new label strings appended in Task 2.
+- `package.json` — new contributions; respect existing structure.
+
+### External (consumed, not modified)
+- `vscode.commands.executeCommand('workbench.action.terminal.copySelection')` — built-in, stable.
+- `vscode.env.clipboard` — stable since VS Code 1.32.
+- No new npm dependencies.
+
+### Cross-task (within this epic)
+- Task 2 depends on Task 1 (imports the extracted pickers and the new portable helpers).
+- Task 3 depends on Task 2 (docs describe the shipped feature).
+
+## Success Criteria (Technical)
+
+- Selecting `git status` in the integrated terminal, right-clicking, choosing the new menu item, picking `Project Shared` + `Allow`, pressing Enter on the pre-filled `Bash(git status:*)` writes that exact rule to `.claude/settings.json` in ≤ 5 user actions.
+- Running the palette command with no terminal selection shows the rejection toast and writes nothing.
+- After running the flow with arbitrary clipboard contents, `vscode.env.clipboard.readText()` returns the original contents (verified by unit test simulating both success and exception paths).
+- Multi-line selection (containing `\n` or `\r`) triggers the rejection toast and aborts cleanly.
+- Existing `claudeConfig.addPermissionRule` test suite passes unchanged after the Task 1 refactor.
+- `npm run typecheck`, `npm run lint`, `npm run test`, and `npm run package` all pass.
+- `wrapAsBashRule` and `validateSingleLineSelection` import nothing from `vscode` (verified by `grep -L "from 'vscode'"` on those exports' module).
+
+## Estimated Effort
+
+- **Code surface**: ~80–120 lines net new + ~50 lines moved during the Task 1 refactor.
+- **Resources**: single developer; PRD decisions are locked, no design or product review needed.
+- **Critical path**: Task 1 → Task 2. Task 3 trails Task 2.
+
+## Tasks Created
+- [ ] #16 - Refactor pickers + add portable helpers (parallel: true)
+- [ ] #17 - Implement claudeConfig.addPermissionFromTerminalSelection (parallel: false)
+- [ ] #18 - Docs (parallel: false)
+
+Total tasks: 3
+Parallel tasks: 1
+Sequential tasks: 2
+Estimated total effort: 9 hours

--- a/.claude/epics/terminal-add-permission/github-mapping.md
+++ b/.claude/epics/terminal-add-permission/github-mapping.md
@@ -1,0 +1,12 @@
+# GitHub Issue Mapping
+
+Epic: #15 — https://github.com/agnislav/claude-code-config-manager/issues/15
+
+Tasks:
+- #16: Refactor pickers + add portable helpers — https://github.com/agnislav/claude-code-config-manager/issues/16
+- #17: Implement claudeConfig.addPermissionFromTerminalSelection — https://github.com/agnislav/claude-code-config-manager/issues/17
+- #18: Docs — https://github.com/agnislav/claude-code-config-manager/issues/18
+
+Worktree: ../epic-terminal-add-permission (branch: epic/terminal-add-permission)
+
+Synced: 2026-04-27T17:54:26Z

--- a/.claude/epics/tree-click-reveal-only-if-open/20-analysis.md
+++ b/.claude/epics/tree-click-reveal-only-if-open/20-analysis.md
@@ -1,0 +1,48 @@
+---
+issue: 20
+title: "Reveal-only-if-open: helper, handler gate, tests, and docs"
+analyzed: 2026-04-28T10:45:02Z
+estimated_hours: 1.5
+parallelization_factor: 1.0
+---
+
+# Parallel Work Analysis: Issue #20
+
+## Overview
+
+Single-stream task. The helper, the call-site gate, and the tests all touch the same file pair (`src/commands/openFileCommands.ts` + new `test/suite/commands/openFileCommands.test.ts`). The CHANGELOG line is trivial. Splitting this into multiple agents would create merge churn for zero wall-time win.
+
+## Parallel Streams
+
+### Stream A: Reveal-only-if-open implementation + tests + docs
+**Scope**: Add `isFileOpenInAnyTab` helper, gate the `showTextDocument` call inside `claudeConfig.revealInFile`, add a new test suite covering both paths, document the behavior change in CHANGELOG.
+**Files**:
+- `src/commands/openFileCommands.ts` (edit — add helper near top, gate at line ~141 before `showTextDocument`)
+- `test/suite/commands/openFileCommands.test.ts` (new file — two cases)
+- `CHANGELOG.md` (edit — add `### Changed` line under next milestone or new `[Unreleased]` heading)
+**Can Start**: immediately
+**Estimated Hours**: 1.5
+**Dependencies**: none
+
+## Coordination Points
+
+### Shared Files
+None — single stream owns all touched files.
+
+### Sequential Requirements
+1. Helper + gate land first (one Edit).
+2. Tests reference the new behavior — written second.
+3. CHANGELOG line last so it accurately reflects what shipped.
+
+## Conflict Risk Assessment
+
+**Low**. The handler is small, the gate is a 3-line insertion before `showTextDocument`, and the test directory `test/suite/commands/` is new. No other open work touches `openFileCommands.ts`.
+
+## Parallelization Strategy
+
+**Single stream** — execute inline in the worktree at `../epic-tree-click-reveal-only-if-open`. No agent dispatch overhead; the change is small enough that a focused implementation pass + verification is faster than spawning a sub-agent.
+
+## Expected Timeline
+- With "parallel" execution: 1.5h (single stream)
+- Without: 1.5h
+- Efficiency gain: 0% (nothing to parallelize)

--- a/.claude/epics/tree-click-reveal-only-if-open/20.md
+++ b/.claude/epics/tree-click-reveal-only-if-open/20.md
@@ -1,0 +1,88 @@
+---
+name: Reveal-only-if-open: helper, handler gate, tests, and docs
+status: open
+created: 2026-04-27T18:12:35Z
+updated: 2026-04-27T18:12:35Z
+github: https://github.com/agnislav/claude-code-config-manager/issues/20
+depends_on: []
+parallel: false
+conflicts_with: []
+---
+
+# Task: Reveal-only-if-open: helper, handler gate, tests, and docs
+
+## Description
+
+Change `claudeConfig.revealInFile` so it only reveals/highlights a config file that is already open in some tab group; if the file is not open, the handler returns silently without calling `showTextDocument`. The companion `claudeConfig.openFile` command is left untouched as the intentional-open path.
+
+The whole change lands as one task because the helper, the call-site gate, and the tests are tightly coupled — they share the same file pair (`src/commands/openFileCommands.ts` and a new `test/suite/commands/openFileCommands.test.ts`) and there is no parallelization win in splitting them.
+
+## Acceptance Criteria
+
+- [ ] Add helper `isFileOpenInAnyTab(uri: vscode.Uri): boolean` that iterates `vscode.window.tabGroups.all[*].tabs[*].input` and returns true when any `TabInputText` has a matching `uri.fsPath`.
+- [ ] In the `claudeConfig.revealInFile` handler at `src/commands/openFileCommands.ts:142`, call the helper after the existing input validations (1–7) and before `vscode.window.showTextDocument(uri)`. If the helper returns false, return silently — no error, no status-bar message, no new tab.
+- [ ] `claudeConfig.openFile` behavior is unchanged — explicit opens from context menu / toolbar still open closed files.
+- [ ] New test file `test/suite/commands/openFileCommands.test.ts` covers:
+  - [ ] Reveal path: open a fixture config file in the test workspace, fire `claudeConfig.revealInFile`, assert the active editor matches and the selection/range was set.
+  - [ ] No-op path: ensure the fixture is not open in any tab, fire `claudeConfig.revealInFile`, assert no new editor was opened (`vscode.window.tabGroups.all` count unchanged) and no error surfaced.
+- [ ] `npm run lint` clean, `npm run typecheck` clean, `npm run test` green.
+- [ ] `CHANGELOG.md` `### Changed` section under the next milestone documents the behavior change in one line.
+- [ ] Optional: README screenshot caption / blurb that describes tree-click behavior is updated if it currently claims "click opens the file".
+
+## Technical Details
+
+**Helper signature & placement**
+```ts
+// src/commands/openFileCommands.ts (or src/utils/editorState.ts if reused later)
+export function isFileOpenInAnyTab(uri: vscode.Uri): boolean {
+  const target = uri.fsPath;
+  for (const group of vscode.window.tabGroups.all) {
+    for (const tab of group.tabs) {
+      const input = tab.input;
+      if (input instanceof vscode.TabInputText && input.uri.fsPath === target) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+```
+
+**Handler gate** at `src/commands/openFileCommands.ts:142`:
+```ts
+// after all existing validations, before showTextDocument:
+if (!isFileOpenInAnyTab(uri)) {
+  return; // silent no-op — the tree click still selects the item
+}
+const editor = await vscode.window.showTextDocument(uri, { preview: false });
+// ... existing range/selection logic unchanged
+```
+
+**Why `tabGroups`, not `visibleTextEditors`**: a file in a non-active tab still counts as "open" — `visibleTextEditors` would miss it and produce surprising no-ops when a user has multiple tabs in one group.
+
+**Why `fsPath` equality**: the `revealInFile` argument is a path string; tab inputs are `vscode.Uri`. Comparing by `fsPath` normalizes path separators and cases on Windows/macOS.
+
+**Test fixture pattern**: follow `test/suite/viewmodel/builder.test.ts`. Use a temp workspace with a `settings.json` fixture; open it via `vscode.workspace.openTextDocument` + `showTextDocument` for the reveal case; for the no-op case, ensure the fixture is referenced only by URI and never opened. Snapshot `vscode.window.tabGroups.all.flatMap(g => g.tabs).length` before and after.
+
+## Dependencies
+
+- **Internal**: `src/commands/openFileCommands.ts` (only file changed); `src/viewmodel/builder.ts` (read-only — confirms command ID and arg shape).
+- **External**: `vscode.window.tabGroups` API (stable since 1.66+; engine target already covers it).
+- **Blocking**: none.
+
+## Effort Estimate
+
+- Size: S
+- Hours: 1–2
+- Code: 15–30 lines (helper + gate + import).
+- Tests: 40–80 lines (two suite cases + fixture).
+- Docs: 3–5 lines in CHANGELOG.
+
+## Definition of Done
+
+- [ ] Code implemented per acceptance criteria.
+- [ ] Tests written and passing locally (`npm run test`).
+- [ ] `npm run lint` and `npm run typecheck` clean.
+- [ ] Manual verification in Extension Development Host: click 5+ tree items with no config files open → zero new tabs; open one config file, click a matching tree item → reveal + range highlight works; right-click → "Open File" still opens unconditionally.
+- [ ] CHANGELOG entry added under the next milestone.
+- [ ] PR opened against `main`, linked to GitHub epic issue.

--- a/.claude/epics/tree-click-reveal-only-if-open/20.md
+++ b/.claude/epics/tree-click-reveal-only-if-open/20.md
@@ -1,8 +1,8 @@
 ---
 name: Reveal-only-if-open: helper, handler gate, tests, and docs
-status: open
+status: closed
 created: 2026-04-27T18:12:35Z
-updated: 2026-04-27T18:12:35Z
+updated: 2026-05-01T14:59:25Z
 github: https://github.com/agnislav/claude-code-config-manager/issues/20
 depends_on: []
 parallel: false

--- a/.claude/epics/tree-click-reveal-only-if-open/epic.md
+++ b/.claude/epics/tree-click-reveal-only-if-open/epic.md
@@ -1,9 +1,9 @@
 ---
 name: tree-click-reveal-only-if-open
-status: backlog
+status: completed
 created: 2026-04-23T20:47:04Z
-updated: 2026-04-27T18:12:35Z
-progress: 0%
+updated: 2026-05-01T14:59:25Z
+progress: 100%
 prd: .claude/prds/tree-click-reveal-only-if-open.md
 github: https://github.com/agnislav/claude-code-config-manager/issues/19
 ---

--- a/.claude/epics/tree-click-reveal-only-if-open/epic.md
+++ b/.claude/epics/tree-click-reveal-only-if-open/epic.md
@@ -1,0 +1,91 @@
+---
+name: tree-click-reveal-only-if-open
+status: backlog
+created: 2026-04-23T20:47:04Z
+updated: 2026-04-27T18:12:35Z
+progress: 0%
+prd: .claude/prds/tree-click-reveal-only-if-open.md
+github: https://github.com/agnislav/claude-code-config-manager/issues/19
+---
+
+# Epic: tree-click-reveal-only-if-open
+
+## Overview
+
+Change the on-click behavior of tree items so that `claudeConfig.revealInFile` — the default command attached to every data-bearing node via `buildRevealCommand` in `src/viewmodel/builder.ts:85` — no longer opens a closed config file. The command still reveals and highlights the relevant range if the file is already open in any tab group; otherwise it is a no-op (with an optional subtle hint).
+
+Total change surface: one helper (~10 lines), one guarded call site in `src/commands/openFileCommands.ts:142`, one new test file, and a CHANGELOG entry. The view-model and tree layers are untouched.
+
+## Architecture Decisions
+
+- **Gate inside the command handler, not at the view-model layer.** The command is still attached to every node (view-model behavior unchanged); the handler chooses whether to proceed. This keeps the fix localized and leaves the `claudeConfig.openFile` command untouched as the intentional-open path.
+- **Use `vscode.window.tabGroups.all[*].tabs[*].input.uri` to detect open state**, not `visibleTextEditors`. A file can be in a non-active tab — that still counts as "open" for reveal purposes. `visibleTextEditors` would miss it and produce surprising no-ops.
+- **URI comparison via `fsPath` normalization** (or `Uri.toString()`), not raw string equality on the input `filePath` argument. The `revealInFile` argument is a path string; tab inputs are URIs.
+- **Silent no-op for FR4 feedback** (default): the tree click still selects the item; absence of a new tab is the signal. A status-bar hint can be added as a follow-up if users report confusion. Keeps the PR minimal and reversible.
+- **No double-click handling (FR5)**: VS Code TreeView does not natively distinguish single-click-to-select from single-click-to-activate. Adding a custom double-click handler is out of proportion for this change; context-menu / toolbar "Open File" is the explicit open path.
+- **No feature flag / setting**. The new behavior is the correct default; a toggle would add permanent surface area for a one-time behavior correction.
+
+## Technical Approach
+
+### Frontend Components
+No tree-level changes. `buildRevealCommand` continues to emit the same `command` property on every eligible node. The command IDs, argument shapes, and context values are all unchanged.
+
+### Backend Services
+A small helper `isFileOpenInAnyTab(uri: vscode.Uri): boolean` lives alongside the other internal utilities in `src/commands/openFileCommands.ts` (or a short `src/utils/editorState.ts` if we want it reusable). Iterates `vscode.window.tabGroups.all[*].tabs[*].input` and checks for a `TabInputText` (or equivalent) whose `uri.fsPath === uri.fsPath`.
+
+The `claudeConfig.revealInFile` handler gains one conditional before `vscode.window.showTextDocument(uri)` at line 142: if `!isFileOpenInAnyTab(uri)` return silently. All existing validations (1–7) run first so invalid inputs continue to surface errors identically.
+
+### Infrastructure
+None. No new dependencies, no new commands, no new view registrations. `vscode.window.tabGroups` has been stable since 1.66+ and the extension already targets a compatible engine.
+
+## Implementation Strategy
+
+- **Sequencing**: helper + handler change land together in a single commit (they are coupled). Tests land in the same PR so CI validates the behavior end-to-end. CHANGELOG in the same PR.
+- **Risk**: the change is semantically reversible by deleting two lines (the helper call and the early return). No data is touched. Risk is mostly UX: existing users may briefly miss the auto-open convenience. Mitigation is a clear CHANGELOG entry.
+- **Testing approach**: use the existing `vscode-test` suite pattern (`test/suite/**/*.test.ts`). Open a fixture file, verify reveal; close it, verify no-op by asserting no new editor is opened. Tests run in the extension host so the `tabGroups` API is real, not mocked.
+
+## Task Breakdown Preview
+
+1. **Implement conditional reveal** — add `isFileOpenInAnyTab` helper and gate the `showTextDocument` call in `claudeConfig.revealInFile`. `src/commands/openFileCommands.ts`. ~15 lines.
+2. **Add test coverage** — new file `test/suite/commands/openFileCommands.test.ts` with two cases: file-open path (reveal + range highlight), file-closed path (no new tab opened, no error). Uses the existing test fixture pattern from `test/suite/viewmodel/builder.test.ts`.
+3. **Documentation** — `CHANGELOG.md` entry under the next milestone noting the behavior change; brief `README.md` note if the screenshots or user-facing docs describe tree-click behavior.
+
+Three tasks total. Task 1 and task 2 can be drafted in parallel once the helper signature is agreed; task 3 is trivial and lands last.
+
+## Dependencies
+
+### Internal
+- `src/commands/openFileCommands.ts` — the only source file that changes.
+- `src/viewmodel/builder.ts` — **read-only** dependency; no edits. Used to confirm the command ID and argument shape.
+- `test/suite/` — new subdirectory `commands/` added.
+
+### External
+- VS Code `tabGroups` API (1.66+). Already available.
+
+### Blocking
+- None. No other epic or feature is a prerequisite.
+- No dependency on `multi-select-item-operations`, `entity-type-view`, or `permission-scaffolding` — this epic is independent and can ship in any milestone.
+
+## Success Criteria (Technical)
+
+- Clicking a tree item whose backing file is **closed** invokes `claudeConfig.revealInFile` and returns without calling `showTextDocument`. Confirmed by test.
+- Clicking a tree item whose backing file is **open** (in any tab group, visible or not) reveals and highlights the range. Confirmed by test.
+- `claudeConfig.openFile` command behavior is unchanged. Confirmed by test (existing or new).
+- All existing tests pass. `npm run lint` and `npm run typecheck` clean.
+- `CHANGELOG.md` documents the behavior change in the next milestone's `### Changed` section.
+
+## Estimated Effort
+
+- **Code**: 15–30 lines (helper + handler gate + imports).
+- **Tests**: 40–80 lines (two `suite()` cases + fixture setup).
+- **Docs**: 3–5 lines in CHANGELOG, optional README tweak.
+- **Total**: ~1–2 hours of focused work, including local manual verification.
+- **Critical path**: single-task — no parallelization win from splitting further.
+
+## Tasks Created
+- [ ] 001.md - Reveal-only-if-open: helper, handler gate, tests, and docs (parallel: false)
+
+Total tasks: 1
+Parallel tasks: 0
+Sequential tasks: 1
+Estimated total effort: 1–2 hours

--- a/.claude/epics/tree-click-reveal-only-if-open/github-mapping.md
+++ b/.claude/epics/tree-click-reveal-only-if-open/github-mapping.md
@@ -1,0 +1,8 @@
+# GitHub Issue Mapping
+
+Epic: #19 - https://github.com/agnislav/claude-code-config-manager/issues/19
+
+Tasks:
+- #20: Reveal-only-if-open: helper, handler gate, tests, and docs - https://github.com/agnislav/claude-code-config-manager/issues/20
+
+Synced: 2026-04-27T18:12:35Z

--- a/.claude/epics/tree-click-reveal-only-if-open/updates/20/execution.md
+++ b/.claude/epics/tree-click-reveal-only-if-open/updates/20/execution.md
@@ -1,0 +1,8 @@
+## Active Streams
+(none)
+
+## Queued
+(none)
+
+## Completed
+- Stream A: Reveal-only-if-open implementation + tests + docs — Completed 2026-04-28T10:50:00Z (inline)

--- a/.claude/epics/tree-click-reveal-only-if-open/updates/20/stream-A.md
+++ b/.claude/epics/tree-click-reveal-only-if-open/updates/20/stream-A.md
@@ -1,0 +1,20 @@
+---
+issue: 20
+stream: Reveal-only-if-open implementation + tests + docs
+started: 2026-04-28T10:45:02Z
+completed: 2026-04-28T10:50:00Z
+status: completed
+---
+
+## Scope
+- Add `isFileOpenInAnyTab(uri: vscode.Uri): boolean` helper in `src/commands/openFileCommands.ts`.
+- Gate the `showTextDocument` call inside `claudeConfig.revealInFile` after validation 7.
+- New test file `test/suite/commands/openFileCommands.test.ts` covering reveal path and no-op path.
+- CHANGELOG entry under `[Unreleased]` documenting the behavior change.
+
+## Progress
+- 2026-04-28T10:45:02Z: stream started — analysis written, beginning implementation
+- 2026-04-28T10:46:00Z: helper + handler gate added in `src/commands/openFileCommands.ts` (15 lines, including a log line for the skip path)
+- 2026-04-28T10:47:00Z: `test/runTests.ts` extended to launch with `test-fixtures/` as workspace folder so project-shared paths land in `buildKnownConfigPaths()`; new test file `test/suite/commands/openFileCommands.test.ts` with 4 cases (helper closed/open + command reveal/no-op)
+- 2026-04-28T10:48:00Z: `npm run typecheck` + `npm run lint` clean; `npm run test` 136 passing (4 new)
+- 2026-04-28T10:50:00Z: CHANGELOG `[Unreleased] / ### Changed` line added; ready to commit + PR

--- a/.claude/epics/tree-double-click-opens-file/001.md
+++ b/.claude/epics/tree-double-click-opens-file/001.md
@@ -1,0 +1,38 @@
+---
+name: Implement double-click-to-open on tree leaves
+status: open
+created: 2026-04-28T17:23:30Z
+updated: 2026-04-28T17:23:30Z
+github: (will be set on sync)
+depends_on: []
+parallel: false
+conflicts_with: []
+---
+
+# Task 001: Implement double-click-to-open on tree leaves
+
+Single coherent change implementing the entire `tree-double-click-opens-file` epic. No sub-tasks — this is one PR's worth of work.
+
+## Scope
+
+1. **Constant** — add `DOUBLE_CLICK_THRESHOLD_MS = 300` in `src/constants.ts`.
+2. **Signature** — `computeCommand` in `src/viewmodel/builder.ts` gains a `nodeId: string` parameter passed as the 3rd `arguments[]` element. Update all call sites (currently 9) to pass `ctx.id` (the same id used for `vm.id`).
+3. **Handler** — `claudeConfig.revealInFile` in `src/commands/openFileCommands.ts`:
+   - Module-level `lastClick: { nodeId: string; time: number } | null = null`.
+   - Read `workbench.list.openMode`.
+   - Existing validation block + reveal-only-if-open block run unchanged (single-click semantics preserved).
+   - New branch at the end: if `openMode === 'doubleClick'` OR if `(now - lastClick.time < DOUBLE_CLICK_THRESHOLD_MS && lastClick.nodeId === nodeId)`, call extracted helper `openAndPosition(uri, filePath, keyPath)`.
+   - Update `lastClick` after each invocation that has a `nodeId`.
+4. **Tests** — add 4 cases to `test/suite/commands/openFileCommands.test.ts`:
+   - Two invocations with same `nodeId` within 300 ms on closed file → file opens, cursor positioned.
+   - Two invocations with same `nodeId` outside 300 ms on closed file → still no-op.
+   - Two invocations with different `nodeId` within 300 ms on closed file → no-op.
+   - With `workbench.list.openMode = 'doubleClick'`, single invocation on closed file → file opens, cursor positioned. (Restore the setting in teardown.)
+5. **CHANGELOG** — add a one-line entry under the next `[Unreleased]` section in `CHANGELOG.md`.
+
+## Acceptance
+
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` green (existing + 4 new tests).
+- Manual E2E in Extension Development Host (5 scenarios from the PRD's Success Criteria) confirmed by hand. (Recorded in commit body.)

--- a/.claude/epics/tree-double-click-opens-file/23.md
+++ b/.claude/epics/tree-double-click-opens-file/23.md
@@ -2,8 +2,8 @@
 name: Implement double-click-to-open on tree leaves
 status: open
 created: 2026-04-28T17:23:30Z
-updated: 2026-04-28T17:23:30Z
-github: (will be set on sync)
+updated: 2026-05-01T14:59:25Z
+github: https://github.com/agnislav/claude-code-config-manager/issues/23
 depends_on: []
 parallel: false
 conflicts_with: []

--- a/.claude/epics/tree-double-click-opens-file/epic.md
+++ b/.claude/epics/tree-double-click-opens-file/epic.md
@@ -1,0 +1,96 @@
+---
+name: tree-double-click-opens-file
+status: backlog
+created: 2026-04-28T17:23:30Z
+updated: 2026-04-28T17:23:30Z
+progress: 0%
+prd: .claude/prds/tree-double-click-opens-file.md
+github: (will be set on sync)
+---
+
+# Epic: tree-double-click-opens-file
+
+## Overview
+
+Add a double-click gesture on tree leaf nodes that opens the backing config file (if not already open) and positions the cursor at the matching JSON key. Implementation is fully contained inside the existing `claudeConfig.revealInFile` command handler — no new commands, no new tree node classes, no new user settings. The handler gains in-memory click-pair detection and an extracted `openAndPosition` helper.
+
+## Architecture Decisions
+
+1. **Detect double-click inside the bound command, not in the tree provider.** VS Code `TreeView` has no native double-click event, only `TreeItem.command` which fires once per activation gesture. Tracking last-click `{nodeId, time}` in module state inside the command is the standard workaround and keeps tree code agnostic of click semantics.
+
+2. **Single-click semantics unchanged.** The existing reveal-only-if-open path runs first, every time. The double-click branch runs *additionally* on the qualifying second fire. This means single-click incurs zero added latency and no behavioral change — the new gesture is purely additive.
+
+3. **Pass `nodeId` as a positional `arguments[]` element.** The command stays at id `claudeConfig.revealInFile`. Adding `nodeId` as the 3rd arg keeps the surface backward-compatible (omitted callers still work, they just lose dbl-click detection — currently no such callers exist outside the tree).
+
+4. **Read `workbench.list.openMode` per-invocation, not at activation.** Users may toggle this VS Code setting at any time. Reading it on each handler entry is O(1) and avoids stale state.
+
+5. **No throttling, no async timer.** The "wait for a possible 2nd click" approach (timeout-based) would add latency to every single click. We instead act on the 1st click immediately AND check the debounce on the 2nd click — works because `revealInFile` is silent for closed files, so a "premature" first action is invisible.
+
+## Technical Approach
+
+### Frontend Components
+None. Tree-item construction (`baseNode.ts`) is unchanged — it already binds whatever `command` the view-model provides.
+
+### Backend Services
+- **`src/viewmodel/builder.ts`** — `computeCommand(collapsibleState, filePath, keyPath)` becomes `computeCommand(collapsibleState, filePath, keyPath, nodeId)`. Pass `ctx.id` (the same id used for `vm.id`) at all 9 call sites. The 3rd arg of the `vscode.Command.arguments` array becomes `nodeId`.
+- **`src/commands/openFileCommands.ts`** — `revealInFile` handler:
+  - Module-level `let lastClick: { nodeId: string; time: number } | null = null;`
+  - Read `openMode` via `vscode.workspace.getConfiguration('workbench.list').get<string>('openMode')`.
+  - Run all existing validations (lines 103-151) unchanged.
+  - Run the existing reveal-only-if-open block (lines 154-173) unchanged — that's the single-click semantic.
+  - **New branch** at the end:
+    ```
+    const isExplicitDoubleClick = openMode === 'doubleClick';
+    const isDebounceMatch =
+      nodeId !== undefined &&
+      lastClick !== null &&
+      lastClick.nodeId === nodeId &&
+      now - lastClick.time < DOUBLE_CLICK_THRESHOLD_MS;
+    if (isExplicitDoubleClick || isDebounceMatch) {
+      await openAndPosition(uri, filePath, keyPath);
+    }
+    lastClick = nodeId !== undefined ? { nodeId, time: now } : null;
+    ```
+  - Extract `openAndPosition(uri, filePath, keyPath)` from existing reveal block (lines 161-173) — `showTextDocument` + `findKeyLine` + `selection`/`revealRange`. Used by both the existing reveal branch and the new dbl-click branch (DRY).
+- **`src/constants.ts`** — `export const DOUBLE_CLICK_THRESHOLD_MS = 300;` near `MAX_KEYPATH_DEPTH`.
+
+### Infrastructure
+None.
+
+## Implementation Strategy
+
+Sequential within the epic, since 002 depends on 001's signature change:
+
+1. **001 first** — pure signature plumbing; type-check after to catch any miss.
+2. **002 second** — handler logic; uses the new `nodeId` arg.
+3. **003 + 004 in parallel** — tests and CHANGELOG don't conflict.
+
+Risk mitigations:
+- Existing tests cover the silent-no-op single-click case → regression detector for free.
+- New tests pin all four behavioral combinations (debounce-hit / debounce-miss / different-node / openMode=doubleClick) so future refactors can't silently break the contract.
+
+## Task Breakdown Preview
+
+- **001** — Implement double-click-to-open: `nodeId` plumbing + handler debounce + `openAndPosition` helper + 4 test cases + CHANGELOG entry. Single coherent change; nothing here is parallelizable. [parallel: false]
+
+## Dependencies
+
+- **Internal**: `findKeyLine` in `src/utils/jsonLocation.ts` (already used by reveal); `isFileOpenInAnyTab` (already used by reveal); `MESSAGES`, `MAX_KEYPATH_DEPTH` constants (already imported).
+- **External**: VS Code 1.90+ (already required for `tabGroups`). `workbench.list.openMode` is a long-stable user setting.
+- **PRD**: `.claude/prds/tree-double-click-opens-file.md`.
+
+## Success Criteria (Technical)
+
+- `npm run typecheck`, `npm run lint`, `npm run test` all green.
+- New tests pass for: debounce-hit opens file, debounce-miss (timing) does not, debounce-miss (different node) does not, openMode=doubleClick opens on single fire.
+- Existing reveal-only-if-open tests pass unchanged.
+- Manual E2E: 5 closed-file double-clicks → 5 correctly positioned opens; 20 single-clicks → 0 opens.
+
+## Estimated Effort
+
+~1.5-2 hours, single task:
+- nodeId plumbing across 9 call sites: ~15 min
+- handler logic + extract helper: ~45 min
+- 4 tests: ~30 min
+- CHANGELOG line: ~5 min
+- typecheck/lint/test + manual E2E in Extension Development Host: ~15 min

--- a/.claude/epics/tree-double-click-opens-file/epic.md
+++ b/.claude/epics/tree-double-click-opens-file/epic.md
@@ -2,10 +2,10 @@
 name: tree-double-click-opens-file
 status: backlog
 created: 2026-04-28T17:23:30Z
-updated: 2026-04-28T17:23:30Z
+updated: 2026-05-01T14:59:25Z
 progress: 0%
 prd: .claude/prds/tree-double-click-opens-file.md
-github: (will be set on sync)
+github: https://github.com/agnislav/claude-code-config-manager/issues/22
 ---
 
 # Epic: tree-double-click-opens-file

--- a/.claude/epics/tree-double-click-opens-file/github-mapping.md
+++ b/.claude/epics/tree-double-click-opens-file/github-mapping.md
@@ -1,0 +1,8 @@
+# GitHub Issue Mapping
+
+Epic: #22 — https://github.com/agnislav/claude-code-config-manager/issues/22
+
+Tasks:
+- #23: Implement double-click-to-open on tree leaves — https://github.com/agnislav/claude-code-config-manager/issues/23
+
+Synced: 2026-05-01T14:59:25Z

--- a/.claude/prds/tree-click-reveal-only-if-open.md
+++ b/.claude/prds/tree-click-reveal-only-if-open.md
@@ -1,0 +1,117 @@
+---
+name: tree-click-reveal-only-if-open
+description: Tree-item clicks reveal-and-highlight the config file only if it is already open in an editor; never auto-open a closed file
+status: backlog
+created: 2026-04-23T15:53:45Z
+---
+
+# PRD: tree-click-reveal-only-if-open
+
+## Source Ideas
+
+This PRD was scoped from the following quick capture(s):
+
+- **2026-04-22**: Tree click must NOT open the config file if it is not already opened — current behavior always opens; should only reveal/highlight when the file is already in an editor (`#ui #tree-click #behavior`)
+
+## Executive Summary
+
+Today every data-bearing tree item carries a default on-click command (`claudeConfig.revealInFile`) that unconditionally opens the backing config file in an editor if it is not already open. This makes the tree a noisy navigator: a single click on a permission rule to inspect it spawns a new editor tab for the underlying `settings.json`, even when the user was just browsing.
+
+This PRD changes the rule: **clicking a tree item reveals and highlights the file only if it is already visible in an editor; if it is not open, the click is a no-op (or a subtle affordance) and does not create a new tab.** Explicit opening remains available through the existing `claudeConfig.openFile` command (context menu / toolbar).
+
+## Problem Statement
+
+**Current behavior** (verified against code):
+- `src/viewmodel/builder.ts:85` assigns `command: 'claudeConfig.revealInFile'` to every data-bearing tree item.
+- `src/commands/openFileCommands.ts:142` unconditionally calls `vscode.window.showTextDocument(uri)`, which opens the file if closed.
+- Net effect: single-click on any tree item always opens the config file.
+
+**Desired behavior**:
+- Click on a tree item whose config file is **already open** in an editor tab → reveal/focus that editor and highlight the corresponding range (current reveal logic).
+- Click on a tree item whose config file is **not open** → do not open it. Either a no-op, or a subtle status bar / tooltip hint such as "Use Open File to edit."
+
+## User Stories
+
+### Story 1: Browse without editor-tab spam
+**As** a user auditing permissions across scopes
+**I want** to click through tree items without each click popping a new editor tab
+**So that** my editor group stays clean while I browse.
+
+### Story 2: Intentional file open
+**As** a user who decides to edit a rule
+**I want** an explicit way to open the config file (context menu, toolbar button, or double-click)
+**So that** opening is always an intentional action, not a side effect of browsing.
+
+### Story 3: Reveal still works on open files
+**As** a user who already has `settings.json` open and clicks a tree item
+**I want** the editor to jump to the matching range
+**So that** the tree remains a navigator for files I'm actively editing.
+
+## Functional Requirements
+
+### FR1: Detect whether the backing file is already open
+- A file is considered "open" if its URI matches any `vscode.window.tabGroups.all[*].tabs[*].input.uri` (preferred over `visibleTextEditors`, which misses non-active tabs).
+- Include tabs that are not currently visible — being in *any* tab group counts as open.
+
+### FR2: Modify `claudeConfig.revealInFile` to conditionally no-op
+- If the file is open: proceed with existing reveal logic (`showTextDocument` + range highlight).
+- If the file is not open: do not call `showTextDocument`. Return without side effects, or (optional) show a transient status-bar message or info hint.
+
+### FR3: Keep `claudeConfig.openFile` as the explicit open path
+- Context-menu "Open File" continues to open unconditionally — this is the intentional open action.
+- Toolbar "Open in editor" (if present per scope) continues to open unconditionally.
+
+### FR4: No-op feedback (decision point)
+Pick one:
+- **Silent no-op** (simplest): click does nothing visible. Discoverable via context menu.
+- **Status-bar hint**: transient message "Use Open File to edit {filename}".
+- **Inline affordance**: a one-time tooltip / notification on first click explaining the change.
+
+### FR5: Double-click behavior (decision point)
+- **Option A**: double-click opens the file (treats double-click as the explicit open). Matches common file-tree UX.
+- **Option B**: no special double-click handling; user must use context menu. Simpler; keeps a single click model.
+
+## Non-Functional Requirements
+
+- **Backward compatibility**: `claudeConfig.revealInFile` keeps its command ID and arguments. Only the internal behavior changes.
+- **Performance**: the "is file open" check is O(open tabs), negligible.
+- **No new state**: no persisted toggle; behavior is uniform.
+
+## Success Criteria
+
+- Clicking 20 different tree items with no config files open creates zero new editor tabs.
+- Clicking a tree item whose file is already open reveals + highlights as before.
+- `claudeConfig.openFile` still opens files unconditionally from menus/toolbar.
+- Existing tests for `revealInFile` updated: positive path when file is open, new negative path when file is closed.
+
+## Constraints & Assumptions
+
+### Constraints
+- No changes to tree node construction or `vmToNode`. All behavior lives inside the `revealInFile` command handler.
+- No changes to the view-model `buildRevealCommand` output — the command is still attached to every node.
+
+### Assumptions (decisions to confirm)
+1. **No-op feedback (FR4)**: silent no-op is the simplest default. A small status-bar hint could help discoverability. Pick one.
+2. **Double-click (FR5)**: VS Code TreeView does not natively distinguish single-click-to-select from single-click-to-activate; the `command` field fires on the default activation. A true double-click handler is more work and not strictly needed. Lean: skip double-click handling; keep context-menu-only explicit open.
+3. **Tree selection still works**: clicks still select the tree item (that's VS Code's native behavior, independent of the command). No change needed.
+
+## Out of Scope
+
+- Changing the `openFile` command's behavior.
+- Introducing a per-user preference toggle (reveal-always vs reveal-if-open). If the new default is right, a preference is unnecessary.
+- Keyboard-activation behavior (Enter on a selected item) — follows the same command, so inherits the new behavior naturally.
+- Any change to the range highlighting / decoration that happens after reveal.
+
+## Dependencies
+
+### Internal
+- `src/commands/openFileCommands.ts` — main change: gate `showTextDocument` call on tab presence.
+- `src/commands/openFileCommands.ts` — the `claudeConfig.openFile` command stays unchanged.
+- Tests under `src/test/` (or equivalent) covering `revealInFile` — add closed-file case.
+
+### External
+- `vscode.window.tabGroups` API (stable since 1.66+). Current engine target covers this.
+
+### Documentation
+- `CHANGELOG.md` entry under the target milestone: behavior change — tree click no longer auto-opens closed files.
+- Possibly a README note so existing users understand the new behavior.

--- a/.claude/prds/tree-double-click-opens-file.md
+++ b/.claude/prds/tree-double-click-opens-file.md
@@ -1,0 +1,121 @@
+---
+name: tree-double-click-opens-file
+description: Double-click on a tree leaf opens the backing settings file (if closed) and positions the cursor at the matching JSON key
+status: backlog
+created: 2026-04-28T17:23:30Z
+---
+
+# PRD: tree-double-click-opens-file
+
+## Source Ideas
+
+This PRD resolves the open question left in the predecessor PRD `tree-click-reveal-only-if-open` (`.claude/prds/tree-click-reveal-only-if-open.md`, FR5):
+
+> "**Option A**: double-click opens the file (treats double-click as the explicit open). Matches common file-tree UX.
+> **Option B**: no special double-click handling; user must use context menu."
+
+`tree-click-reveal-only-if-open` shipped Option B (silent no-op when the file is closed) so that single-click stayed cheap for browsing. This PRD picks **Option A** as an additive layer — restoring "open via the tree" as an explicit two-click gesture without re-introducing the editor-tab spam single-click used to cause.
+
+## Executive Summary
+
+Today, single-clicking a tree leaf whose backing config file is closed is a silent no-op (good for browsing). The only way to actually open that file from the tree is the context menu's "Open File". This PRD adds a **double-click on a leaf node** gesture that opens the backing config file (if not already open) and moves the cursor to the matching JSON key. Single-click behavior is unchanged.
+
+## Problem Statement
+
+After `tree-click-reveal-only-if-open` shipped:
+- ✅ Single-click no longer spawns editor tabs while browsing.
+- ❌ The keyboard / mouse path for "I actually want to look at this in the file" got slower: right-click → "Open File" → click again to position cursor (the open path doesn't reuse `revealInFile`'s key-line navigation).
+
+Users expect a familiar file-tree gesture: **double-click to open**. We have everything needed (`findKeyLine`, `showTextDocument`) — we just need to detect the second click.
+
+## User Stories
+
+### Story 1: Browse silently (preserved from predecessor PRD)
+**As** a user auditing settings across scopes
+**I want** single-click to stay silent when the file is closed
+**So that** my editor group stays clean while I browse.
+
+**Acceptance**: clicking 20 closed-file leaves spawns 0 editor tabs.
+
+### Story 2: Open + position via double-click
+**As** a user inspecting a specific permission rule
+**I want** to double-click the leaf and have the file open with the cursor on that exact key
+**So that** I can immediately edit it without a separate "find this key" step.
+
+**Acceptance**: with `settings.json` closed, double-clicking the `permissions.allow[2]` leaf opens `settings.json` with the cursor placed at the line containing the matching key.
+
+### Story 3: Idempotent on already-open files
+**As** a user with `settings.json` already open
+**I want** double-click to behave the same as single-click (reveal + position)
+**So that** the gesture is harmless and predictable.
+
+**Acceptance**: with the file already open, single-click and double-click produce the same final cursor position; no extra tab is created.
+
+## Functional Requirements
+
+### FR1: Detect a double-click via debounce inside `claudeConfig.revealInFile`
+- Module-level state `lastClick: { nodeId: string; time: number } | null`.
+- A "double-click" is two invocations with the **same** `nodeId` arriving within `DOUBLE_CLICK_THRESHOLD_MS` (300 ms).
+- Different `nodeId`s within the window do NOT count as a double-click.
+
+### FR2: On double-click of a leaf, open and position
+- Call `vscode.window.showTextDocument(uri)` even if the file is currently closed.
+- Reuse the existing `findKeyLine`-based positioning logic (same code path used today by reveal-when-already-open).
+
+### FR3: Handle `workbench.list.openMode === 'doubleClick'`
+- When this VS Code setting is `'doubleClick'`, native single-click does NOT fire `TreeItem.command` at all — only double-click does. So every fire of `revealInFile` in this mode IS the explicit double-click intent and must run the open-and-position path.
+
+### FR4: Branch nodes unaffected
+- `computeCommand` already returns `undefined` for non-leaf items. They keep VS Code's native expand/collapse-on-doubleclick behavior. No double-click handling is wired to them.
+
+### FR5: All existing validations preserved
+- Path traversal check, known-paths allowlist, `keyPath` shape and depth limit (`MAX_KEYPATH_DEPTH`) all run BEFORE the debounce branch. Invalid input never advances to the open path.
+
+## Non-Functional Requirements
+
+- **Backward-compatible command surface**: command id stays `claudeConfig.revealInFile`. The signature gains an optional 3rd argument (`nodeId: string`); existing callers that omit it still work — they just lose double-click detection (acceptable; no external callers exist).
+- **Memory**: O(1) — a single `lastClick` cell.
+- **Latency**: single-click has zero added latency (the open path is gated on the 2nd click only).
+- **No new user setting**: the threshold is a code constant.
+
+## Success Criteria
+
+1. With all settings tabs closed, double-clicking 5 different leaves opens 5 corresponding files with the cursor positioned at the matching key in each.
+2. Single-click on a closed-file leaf still spawns 0 tabs (regression check on predecessor PRD).
+3. Two single-clicks on different leaves within 300 ms still spawn 0 tabs (different `nodeId`).
+4. With `workbench.list.openMode = 'doubleClick'`, one double-click opens + positions correctly.
+5. Existing `revealInFile` test suite stays green; 4 new tests added pass.
+
+## Constraints & Assumptions
+
+### Constraints
+- VS Code's `TreeView` API exposes no native `onDidDoubleClick`. The only click hook is `TreeItem.command`, fired once per activation gesture. Debounce inside the bound command is the accepted workaround.
+- 300 ms threshold is OS-double-click-default. Not user-configurable in v1.
+- `workbench.list.openMode` is a user setting — we read it at handler entry, not at extension activation, so changes take effect immediately.
+
+### Assumptions
+- `nodeContext.id` (or the tree-item id derived from scope + entityType + keyPath) is stable within a tree refresh — the same logical node produces the same id between refreshes. (Confirmed in `viewmodel/builder.ts` — `id` is computed from the full keyPath.)
+- Users with `openMode = 'singleClick'` (default on most setups) get a real two-click gesture. Users with `openMode = 'doubleClick'` get a one-gesture open. Both are correct, just different.
+
+## Out of Scope
+
+- Configurable threshold (300 ms is hardcoded).
+- Double-click on branch nodes / scope nodes (would conflict with VS Code's native expand/collapse).
+- Keyboard activation (Enter on selected item) — same `command` plumbing already inherits whatever single-click does today.
+- Animations / transient UI hints on detection.
+- A "long-press" or any other custom gesture.
+
+## Dependencies
+
+### Internal
+- `src/commands/openFileCommands.ts` — main change site.
+- `src/viewmodel/builder.ts` — `computeCommand` signature + 9 call sites pass `nodeId` through.
+- `src/constants.ts` — add `DOUBLE_CLICK_THRESHOLD_MS = 300`.
+- `test/suite/commands/openFileCommands.test.ts` — add new tests alongside existing reveal-only-if-open tests.
+
+### External
+- `vscode.workspace.getConfiguration('workbench.list').get<string>('openMode')` — stable VS Code API.
+- `vscode.window.tabGroups` — already used by `isFileOpenInAnyTab`.
+
+### Documentation
+- `CHANGELOG.md` entry under the next milestone documenting the new gesture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the Claude Code Config Manager extension will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Changed
+- Tree-item click no longer auto-opens a closed config file. `claudeConfig.revealInFile` now reveals and highlights the range only if the file is already open in some tab group; otherwise it is a silent no-op. Use the context-menu / toolbar **Open File** action for explicit opens. ([#19](https://github.com/agnislav/claude-code-config-manager/issues/19), [#20](https://github.com/agnislav/claude-code-config-manager/issues/20))
+
 ## [0.10.0] - 2026-03-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+- Double-click a tree leaf to open its backing config file (when closed) and place the cursor at the matching JSON key. Detected via a 300 ms same-node debounce inside `claudeConfig.revealInFile`; also fires on a single click when `workbench.list.openMode` is `doubleClick`. Single-click semantics are unchanged — closed files stay closed.
+
 ### Changed
 - Tree-item click no longer auto-opens a closed config file. `claudeConfig.revealInFile` now reveals and highlights the range only if the file is already open in some tab group; otherwise it is a silent no-op. Use the context-menu / toolbar **Open File** action for explicit opens. ([#19](https://github.com/agnislav/claude-code-config-manager/issues/19), [#20](https://github.com/agnislav/claude-code-config-manager/issues/20))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-config-manager",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-config-manager",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/src/commands/openFileCommands.ts
+++ b/src/commands/openFileCommands.ts
@@ -115,15 +115,6 @@ export function registerOpenFileCommands(
     ),
   );
 
-  // Hidden command used only by the integration test suite to clear the in-memory
-  // double-click debounce state between test cases. Not contributed in package.json,
-  // so it is invisible in the command palette.
-  context.subscriptions.push(
-    vscode.commands.registerCommand('claudeConfig._test_resetDoubleClickState', () => {
-      lastClick = null;
-    }),
-  );
-
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'claudeConfig.revealInFile',

--- a/src/commands/openFileCommands.ts
+++ b/src/commands/openFileCommands.ts
@@ -4,12 +4,31 @@ import * as path from 'path';
 import { ConfigTreeNode } from '../tree/nodes/baseNode';
 import { findKeyLine } from '../utils/jsonLocation';
 import { getUserSettingsPath, getManagedSettingsPath, getUserClaudeJsonPath } from '../utils/platform';
-import { PROJECT_CLAUDE_DIR, PROJECT_SHARED_FILE, PROJECT_LOCAL_FILE, MCP_CONFIG_FILE, MAX_KEYPATH_DEPTH, MESSAGES } from '../constants';
+import { PROJECT_CLAUDE_DIR, PROJECT_SHARED_FILE, PROJECT_LOCAL_FILE, MCP_CONFIG_FILE, MAX_KEYPATH_DEPTH, DOUBLE_CLICK_THRESHOLD_MS, MESSAGES } from '../constants';
 import { formatTimestamp } from '../utils/timestamp';
 
 function logRevealInFile(outputChannel: vscode.OutputChannel | undefined, message: string): void {
   if (!outputChannel) return;
   outputChannel.appendLine(`${formatTimestamp()} [revealInFile] ${message}`);
+}
+
+let lastClick: { nodeId: string; time: number } | null = null;
+
+async function openAndPositionAtKey(
+  uri: vscode.Uri,
+  filePath: string,
+  keyPath: string[],
+): Promise<void> {
+  const editor = await vscode.window.showTextDocument(uri);
+  if (keyPath.length === 0) return;
+  const location = findKeyLine(filePath, keyPath);
+  if (!location) return;
+  const pos = new vscode.Position(location.line, location.lineLength);
+  editor.selection = new vscode.Selection(pos, pos);
+  editor.revealRange(
+    new vscode.Range(pos, pos),
+    vscode.TextEditorRevealType.InCenterIfOutsideViewport,
+  );
 }
 
 export function isFileOpenInAnyTab(uri: vscode.Uri): boolean {
@@ -96,10 +115,19 @@ export function registerOpenFileCommands(
     ),
   );
 
+  // Hidden command used only by the integration test suite to clear the in-memory
+  // double-click debounce state between test cases. Not contributed in package.json,
+  // so it is invisible in the command palette.
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claudeConfig._test_resetDoubleClickState', () => {
+      lastClick = null;
+    }),
+  );
+
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'claudeConfig.revealInFile',
-      async (filePath: string, keyPath: string[]) => {
+      async (filePath: string, keyPath: string[], nodeId?: string) => {
         // Validation 1: Check filePath type and presence
         if (typeof filePath !== 'string' || filePath.length === 0) {
           // Return silently for internal wiring where no path is available
@@ -150,27 +178,37 @@ export function registerOpenFileCommands(
           return;
         }
 
-        // All validations passed - check whether the file is already open before revealing
+        // Decide whether this invocation should open a closed file. Two paths qualify:
+        //  1. The user has VS Code's `workbench.list.openMode` set to `doubleClick`, in
+        //     which case `TreeItem.command` only fires on a real double-click — every
+        //     fire IS the explicit-open intent.
+        //  2. We received two invocations on the same nodeId within the debounce window,
+        //     i.e. a synthesized double-click on top of a `singleClick` openMode.
+        const now = Date.now();
+        const openMode = vscode.workspace
+          .getConfiguration('workbench.list')
+          .get<string>('openMode');
+        const isExplicitDoubleClickMode = openMode === 'doubleClick';
+        const isDebounceMatch =
+          nodeId !== undefined &&
+          lastClick !== null &&
+          lastClick.nodeId === nodeId &&
+          now - lastClick.time < DOUBLE_CLICK_THRESHOLD_MS;
+        const shouldOpenClosedFile = isExplicitDoubleClickMode || isDebounceMatch;
+
+        // Update click state for the next invocation. Done before the await so we
+        // never miss recording a click even if the open path throws.
+        lastClick = nodeId !== undefined ? { nodeId, time: now } : null;
+
         const uri = vscode.Uri.file(filePath);
-        if (!isFileOpenInAnyTab(uri)) {
-          // Silent no-op: the tree click still selects the item; explicit opens go
-          // through `claudeConfig.openFile` (context menu / toolbar).
-          logRevealInFile(outputChannel, `skipped: ${filePath} (not open in any tab)`);
+        if (isFileOpenInAnyTab(uri) || shouldOpenClosedFile) {
+          await openAndPositionAtKey(uri, filePath, keyPath);
           return;
         }
-        const editor = await vscode.window.showTextDocument(uri);
 
-        if (keyPath.length > 0) {
-          const location = findKeyLine(filePath, keyPath);
-          if (location) {
-            const pos = new vscode.Position(location.line, location.lineLength);
-            editor.selection = new vscode.Selection(pos, pos);
-            editor.revealRange(
-              new vscode.Range(pos, pos),
-              vscode.TextEditorRevealType.InCenterIfOutsideViewport,
-            );
-          }
-        }
+        // Silent no-op: the tree click still selects the item; explicit opens go
+        // through `claudeConfig.openFile` (context menu / toolbar) or a double-click.
+        logRevealInFile(outputChannel, `skipped: ${filePath} (not open in any tab)`);
       },
     ),
   );

--- a/src/commands/openFileCommands.ts
+++ b/src/commands/openFileCommands.ts
@@ -12,6 +12,19 @@ function logRevealInFile(outputChannel: vscode.OutputChannel | undefined, messag
   outputChannel.appendLine(`${formatTimestamp()} [revealInFile] ${message}`);
 }
 
+export function isFileOpenInAnyTab(uri: vscode.Uri): boolean {
+  const target = uri.fsPath;
+  for (const group of vscode.window.tabGroups.all) {
+    for (const tab of group.tabs) {
+      const input = tab.input;
+      if (input instanceof vscode.TabInputText && input.uri.fsPath === target) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 function buildKnownConfigPaths(): Set<string> {
   const paths = new Set<string>();
 
@@ -137,8 +150,14 @@ export function registerOpenFileCommands(
           return;
         }
 
-        // All validations passed - proceed with reveal
+        // All validations passed - check whether the file is already open before revealing
         const uri = vscode.Uri.file(filePath);
+        if (!isFileOpenInAnyTab(uri)) {
+          // Silent no-op: the tree click still selects the item; explicit opens go
+          // through `claudeConfig.openFile` (context menu / toolbar).
+          logRevealInFile(outputChannel, `skipped: ${filePath} (not open in any tab)`);
+          return;
+        }
         const editor = await vscode.window.showTextDocument(uri);
 
         if (keyPath.length > 0) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -167,6 +167,9 @@ export const DEACTIVATION_MAX_WAIT_MS = 5000;
 /** Maximum allowed keyPath depth for revealInFile validation. */
 export const MAX_KEYPATH_DEPTH = 10;
 
+/** Window for treating two consecutive `revealInFile` invocations on the same node as a double-click. */
+export const DOUBLE_CLICK_THRESHOLD_MS = 300;
+
 // ── Messages ──────────────────────────────────────────────────
 
 /** Centralized user-facing messages. All prefixed with "Claude Config:" for identification. */

--- a/src/viewmodel/builder.ts
+++ b/src/viewmodel/builder.ts
@@ -74,6 +74,7 @@ function computeCommand(
   collapsibleState: vscode.TreeItemCollapsibleState,
   filePath: string | undefined,
   keyPath: string[],
+  nodeId: string,
 ): vscode.Command | undefined {
   if (
     collapsibleState !== vscode.TreeItemCollapsibleState.None ||
@@ -85,7 +86,7 @@ function computeCommand(
   return {
     command: 'claudeConfig.revealInFile',
     title: 'Reveal in Config File',
-    arguments: [filePath, keyPath],
+    arguments: [filePath, keyPath, nodeId],
   };
 }
 
@@ -526,7 +527,7 @@ export class TreeViewModelBuilder {
       nodeContext: ctx,
       children: [],
       id: computeId(ctx),
-      command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath),
+      command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath, computeId(ctx)),
       resourceUri: buildOverlapResourceUri(scopedConfig.scope, 'permission', `${category}/${rule}`, overlap),
       accessibilityInformation: {
         label: buildOverlapAccessibilityLabel(
@@ -601,7 +602,7 @@ export class TreeViewModelBuilder {
       nodeContext: ctx,
       children,
       id: computeId(ctx),
-      command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath),
+      command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath, computeId(ctx)),
       resourceUri: buildOverlapResourceUri(scopedConfig.scope, 'setting', key, overlap),
       accessibilityInformation: {
         label: buildOverlapAccessibilityLabel(
@@ -656,7 +657,7 @@ export class TreeViewModelBuilder {
       nodeContext: ctx,
       children: [],
       id: computeId(ctx),
-      command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath),
+      command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath, computeId(ctx)),
       resourceUri: buildOverlapResourceUri(scopedConfig.scope, 'settingKeyValue', `${parentKey}.${childKey}`, overlap),
       accessibilityInformation: {
         label: buildOverlapAccessibilityLabel(
@@ -709,7 +710,7 @@ export class TreeViewModelBuilder {
         nodeContext: ctx,
         children: [],
         id: computeId(ctx),
-        command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath),
+        command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath, computeId(ctx)),
         resourceUri: buildOverlapResourceUri(scopedConfig.scope, 'env', key, overlap),
         accessibilityInformation: {
           label: buildOverlapAccessibilityLabel(
@@ -796,7 +797,7 @@ export class TreeViewModelBuilder {
               : vscode.TreeItemCheckboxState.Unchecked }
           : {}),
         resourceUri,
-        command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath),
+        command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath, computeId(ctx)),
         accessibilityInformation: {
           label: buildOverlapAccessibilityLabel(
             `Plugin: ${pluginId}, ${enabled ? 'enabled' : 'disabled'}, ${SCOPE_LABELS[scopedConfig.scope]} scope`,
@@ -873,7 +874,7 @@ export class TreeViewModelBuilder {
       nodeContext: ctx,
       children,
       id: computeId(ctx),
-      command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath),
+      command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath, computeId(ctx)),
       resourceUri: buildOverlapResourceUri(scopedConfig.scope, 'sandbox', key, overlap),
       accessibilityInformation: {
         label: buildOverlapAccessibilityLabel(
@@ -927,7 +928,7 @@ export class TreeViewModelBuilder {
       nodeContext: ctx,
       children: [],
       id: computeId(ctx),
-      command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath),
+      command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath, computeId(ctx)),
       resourceUri: buildOverlapResourceUri(scopedConfig.scope, 'sandbox', `${parentKey}.${childKey}`, overlap),
       accessibilityInformation: {
         label: buildOverlapAccessibilityLabel(
@@ -994,7 +995,7 @@ export class TreeViewModelBuilder {
         nodeContext: ctx,
         children: [],
         id: computeId(ctx),
-        command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath),
+        command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath, computeId(ctx)),
         resourceUri: buildOverlapResourceUri(scopedConfig.scope, 'mcpServer', name, overlap),
         accessibilityInformation: {
           label: buildOverlapAccessibilityLabel(
@@ -1123,7 +1124,7 @@ export class TreeViewModelBuilder {
       nodeContext: ctx,
       children: [],
       id: computeId(ctx),
-      command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath),
+      command: computeCommand(collapsibleState, ctx.filePath, ctx.keyPath, computeId(ctx)),
       resourceUri: buildOverlapResourceUri(scopedConfig.scope, 'hook', `${eventType}/${matcherIndex}/${hookIndex}`, overlap),
       accessibilityInformation: {
         label: buildOverlapAccessibilityLabel(

--- a/test/runTests.ts
+++ b/test/runTests.ts
@@ -4,7 +4,12 @@ import { runTests } from '@vscode/test-electron';
 async function main() {
   const extensionDevelopmentPath = path.resolve(__dirname, '../../');
   const extensionTestsPath = path.resolve(__dirname, './suite/index');
-  await runTests({ extensionDevelopmentPath, extensionTestsPath });
+  const testWorkspace = path.resolve(extensionDevelopmentPath, 'test-fixtures');
+  await runTests({
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    launchArgs: [testWorkspace, '--disable-extensions'],
+  });
 }
 
 main().catch((err) => {

--- a/test/suite/commands/openFileCommands.test.ts
+++ b/test/suite/commands/openFileCommands.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { isFileOpenInAnyTab } from '../../../src/commands/openFileCommands';
+import { DOUBLE_CLICK_THRESHOLD_MS } from '../../../src/constants';
 
 // Resolves the test workspace folder. runTests.ts launches with `test-fixtures/`
 // as the workspace, so the project shared settings file lives at a path that
@@ -24,11 +25,22 @@ function totalTabCount(): number {
 
 suite('openFileCommands.revealInFile (issue #20)', () => {
   suiteSetup(async () => {
+    // Force extension activation so the test-only reset command is registered before
+    // the first teardown runs. Without this, the extension activates lazily on the
+    // first non-direct call, leaving the reset command unknown to teardown.
+    const ext = vscode.extensions.getExtension('agnislav.claude-code-config-manager');
+    assert.ok(ext, 'extension under test must be present');
+    if (!ext!.isActive) {
+      await ext!.activate();
+    }
     await closeAllTabs();
   });
 
   teardown(async () => {
     await closeAllTabs();
+    // The registered command lives in the bundled dist/extension.js — the same module
+    // instance whose `lastClick` state needs to be cleared between cases.
+    await vscode.commands.executeCommand('claudeConfig._test_resetDoubleClickState');
   });
 
   test('isFileOpenInAnyTab returns false when no matching tab is open', async () => {
@@ -72,5 +84,66 @@ suite('openFileCommands.revealInFile (issue #20)', () => {
       activeBefore,
       'active editor must be unchanged',
     );
+  });
+
+  // ── Double-click behavior (tree-double-click-opens-file) ─────────────────
+
+  test('two invocations on same nodeId within window open the closed file and position cursor', async () => {
+    const filePath = getFixtureSharedSettingsPath();
+    const target = vscode.Uri.file(filePath);
+    const tabsBefore = totalTabCount();
+
+    // Two fast clicks on the same logical node — second one should trigger the open path.
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-A');
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-A');
+
+    assert.strictEqual(totalTabCount(), tabsBefore + 1, 'second invocation must open the file');
+    const active = vscode.window.activeTextEditor;
+    assert.ok(active, 'Expected an active editor after double-click open');
+    assert.strictEqual(active!.document.uri.fsPath, target.fsPath);
+  });
+
+  test('two invocations outside the debounce window stay silent', async () => {
+    const filePath = getFixtureSharedSettingsPath();
+    const tabsBefore = totalTabCount();
+
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-A');
+    // Wait past the debounce window so the second click no longer pairs with the first.
+    await new Promise((resolve) => setTimeout(resolve, DOUBLE_CLICK_THRESHOLD_MS + 50));
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-A');
+
+    assert.strictEqual(totalTabCount(), tabsBefore, 'two slow clicks must remain a no-op');
+  });
+
+  test('two invocations on different nodeIds within window stay silent', async () => {
+    const filePath = getFixtureSharedSettingsPath();
+    const tabsBefore = totalTabCount();
+
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-A');
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-B');
+
+    assert.strictEqual(totalTabCount(), tabsBefore, 'fast clicks on different nodes must not be treated as a double-click');
+  });
+
+  test('a single invocation opens the file when workbench.list.openMode is doubleClick', async () => {
+    const filePath = getFixtureSharedSettingsPath();
+    const target = vscode.Uri.file(filePath);
+    const tabsBefore = totalTabCount();
+
+    const config = vscode.workspace.getConfiguration('workbench.list');
+    const previousOpenMode = config.get<string>('openMode');
+    await config.update('openMode', 'doubleClick', vscode.ConfigurationTarget.Workspace);
+
+    try {
+      await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-A');
+
+      assert.strictEqual(totalTabCount(), tabsBefore + 1, 'single invocation in doubleClick openMode must open the file');
+      const active = vscode.window.activeTextEditor;
+      assert.ok(active, 'Expected an active editor after open');
+      assert.strictEqual(active!.document.uri.fsPath, target.fsPath);
+    } finally {
+      // Restore — undefined clears the workspace override and falls back to the user setting.
+      await config.update('openMode', previousOpenMode, vscode.ConfigurationTarget.Workspace);
+    }
   });
 });

--- a/test/suite/commands/openFileCommands.test.ts
+++ b/test/suite/commands/openFileCommands.test.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { isFileOpenInAnyTab } from '../../../src/commands/openFileCommands';
 import { DOUBLE_CLICK_THRESHOLD_MS } from '../../../src/constants';
+import { findKeyLine } from '../../../src/utils/jsonLocation';
 
 // Resolves the test workspace folder. runTests.ts launches with `test-fixtures/`
 // as the workspace, so the project shared settings file lives at a path that
@@ -25,22 +26,11 @@ function totalTabCount(): number {
 
 suite('openFileCommands.revealInFile (issue #20)', () => {
   suiteSetup(async () => {
-    // Force extension activation so the test-only reset command is registered before
-    // the first teardown runs. Without this, the extension activates lazily on the
-    // first non-direct call, leaving the reset command unknown to teardown.
-    const ext = vscode.extensions.getExtension('agnislav.claude-code-config-manager');
-    assert.ok(ext, 'extension under test must be present');
-    if (!ext!.isActive) {
-      await ext!.activate();
-    }
     await closeAllTabs();
   });
 
   teardown(async () => {
     await closeAllTabs();
-    // The registered command lives in the bundled dist/extension.js — the same module
-    // instance whose `lastClick` state needs to be cleared between cases.
-    await vscode.commands.executeCommand('claudeConfig._test_resetDoubleClickState');
   });
 
   test('isFileOpenInAnyTab returns false when no matching tab is open', async () => {
@@ -87,30 +77,58 @@ suite('openFileCommands.revealInFile (issue #20)', () => {
   });
 
   // ── Double-click behavior (tree-double-click-opens-file) ─────────────────
+  //
+  // Each case uses a unique `nodeId` prefix so no test can pair with debounce
+  // state left behind by an earlier case. That keeps the suite hermetic without
+  // needing a state-reset hook on the bundled handler.
 
-  test('two invocations on same nodeId within window open the closed file and position cursor', async () => {
+  test('two invocations on same nodeId within window open the closed file and position cursor at the matching key', async () => {
     const filePath = getFixtureSharedSettingsPath();
     const target = vscode.Uri.file(filePath);
+    const expected = findKeyLine(filePath, ['env']);
+    assert.ok(expected, 'fixture must contain the env key for this test to be meaningful');
     const tabsBefore = totalTabCount();
 
     // Two fast clicks on the same logical node — second one should trigger the open path.
-    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-A');
-    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-A');
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'dbl-open-A');
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'dbl-open-A');
 
     assert.strictEqual(totalTabCount(), tabsBefore + 1, 'second invocation must open the file');
     const active = vscode.window.activeTextEditor;
     assert.ok(active, 'Expected an active editor after double-click open');
     assert.strictEqual(active!.document.uri.fsPath, target.fsPath);
+    // The cursor must land on the line of the JSON key — not just somewhere in the file.
+    assert.strictEqual(active!.selection.active.line, expected!.line, 'cursor must be on the env key line');
+  });
+
+  test('double-click on an already-open file is idempotent (no extra tab, cursor positioned)', async () => {
+    const filePath = getFixtureSharedSettingsPath();
+    const target = vscode.Uri.file(filePath);
+    const expected = findKeyLine(filePath, ['env']);
+    assert.ok(expected);
+
+    // Pre-open the file so the first click is already in the reveal path.
+    const doc = await vscode.workspace.openTextDocument(target);
+    await vscode.window.showTextDocument(doc, { preview: false });
+    const tabsBefore = totalTabCount();
+
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'open-idem-A');
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'open-idem-A');
+
+    assert.strictEqual(totalTabCount(), tabsBefore, 'no second tab should appear when the file was already open');
+    const active = vscode.window.activeTextEditor!;
+    assert.strictEqual(active.document.uri.fsPath, target.fsPath);
+    assert.strictEqual(active.selection.active.line, expected!.line, 'cursor must be on the env key line after the second click');
   });
 
   test('two invocations outside the debounce window stay silent', async () => {
     const filePath = getFixtureSharedSettingsPath();
     const tabsBefore = totalTabCount();
 
-    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-A');
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'win-out-A');
     // Wait past the debounce window so the second click no longer pairs with the first.
     await new Promise((resolve) => setTimeout(resolve, DOUBLE_CLICK_THRESHOLD_MS + 50));
-    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-A');
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'win-out-A');
 
     assert.strictEqual(totalTabCount(), tabsBefore, 'two slow clicks must remain a no-op');
   });
@@ -119,8 +137,8 @@ suite('openFileCommands.revealInFile (issue #20)', () => {
     const filePath = getFixtureSharedSettingsPath();
     const tabsBefore = totalTabCount();
 
-    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-A');
-    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-B');
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'diff-A');
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'diff-B');
 
     assert.strictEqual(totalTabCount(), tabsBefore, 'fast clicks on different nodes must not be treated as a double-click');
   });
@@ -135,7 +153,7 @@ suite('openFileCommands.revealInFile (issue #20)', () => {
     await config.update('openMode', 'doubleClick', vscode.ConfigurationTarget.Workspace);
 
     try {
-      await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'node-A');
+      await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env'], 'mode-dbl-A');
 
       assert.strictEqual(totalTabCount(), tabsBefore + 1, 'single invocation in doubleClick openMode must open the file');
       const active = vscode.window.activeTextEditor;

--- a/test/suite/commands/openFileCommands.test.ts
+++ b/test/suite/commands/openFileCommands.test.ts
@@ -1,0 +1,76 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { isFileOpenInAnyTab } from '../../../src/commands/openFileCommands';
+
+// Resolves the test workspace folder. runTests.ts launches with `test-fixtures/`
+// as the workspace, so the project shared settings file lives at a path that
+// `buildKnownConfigPaths()` will accept.
+function getFixtureSharedSettingsPath(): string {
+  const folders = vscode.workspace.workspaceFolders;
+  assert.ok(folders && folders.length > 0, 'Test workspace folder must be open');
+  return path.join(folders[0].uri.fsPath, '.claude', 'settings.json');
+}
+
+async function closeAllTabs(): Promise<void> {
+  await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+  // Give VS Code a tick to actually drop the tabs from tabGroups.all.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+function totalTabCount(): number {
+  return vscode.window.tabGroups.all.reduce((sum, group) => sum + group.tabs.length, 0);
+}
+
+suite('openFileCommands.revealInFile (issue #20)', () => {
+  suiteSetup(async () => {
+    await closeAllTabs();
+  });
+
+  teardown(async () => {
+    await closeAllTabs();
+  });
+
+  test('isFileOpenInAnyTab returns false when no matching tab is open', async () => {
+    const target = vscode.Uri.file(getFixtureSharedSettingsPath());
+    assert.strictEqual(isFileOpenInAnyTab(target), false);
+  });
+
+  test('isFileOpenInAnyTab returns true after the file is opened', async () => {
+    const target = vscode.Uri.file(getFixtureSharedSettingsPath());
+    const doc = await vscode.workspace.openTextDocument(target);
+    await vscode.window.showTextDocument(doc, { preview: false });
+    assert.strictEqual(isFileOpenInAnyTab(target), true);
+  });
+
+  test('revealInFile reveals when the file is already open', async () => {
+    const filePath = getFixtureSharedSettingsPath();
+    const target = vscode.Uri.file(filePath);
+
+    // Pre-open the fixture so the gate allows the reveal.
+    const doc = await vscode.workspace.openTextDocument(target);
+    await vscode.window.showTextDocument(doc, { preview: false });
+
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env']);
+
+    const active = vscode.window.activeTextEditor;
+    assert.ok(active, 'Expected an active editor after reveal');
+    assert.strictEqual(active!.document.uri.fsPath, target.fsPath);
+  });
+
+  test('revealInFile is a silent no-op when the file is not open', async () => {
+    const filePath = getFixtureSharedSettingsPath();
+    const tabsBefore = totalTabCount();
+    const activeBefore = vscode.window.activeTextEditor?.document.uri.fsPath;
+
+    await vscode.commands.executeCommand('claudeConfig.revealInFile', filePath, ['env']);
+
+    // No new tab opened, no active editor change.
+    assert.strictEqual(totalTabCount(), tabsBefore, 'reveal must not open a new tab when file is closed');
+    assert.strictEqual(
+      vscode.window.activeTextEditor?.document.uri.fsPath,
+      activeBefore,
+      'active editor must be unchanged',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Bundles two related tree-click epics on a single branch:

1. **`tree-click-reveal-only-if-open`** (Epic #19, Task #20) — original predecessor work. Single-click on a tree leaf no longer auto-opens a closed config file; `claudeConfig.revealInFile` now reveals/highlights only when the file is already open in some tab group, otherwise silent no-op. `claudeConfig.openFile` (context menu / toolbar) is unchanged as the explicit open path.

2. **`tree-double-click-opens-file`** (Epic #22, Task #23) — additive layer. **Double-click** a leaf to open the backing config file (when closed) and place the cursor at the matching JSON key. Detected via a 300 ms same-node debounce inside `revealInFile`; also fires on a single command activation when `workbench.list.openMode` is `doubleClick` (the only mode where VS Code emits the command exactly once per real double-click). Single-click semantics from epic 1 are preserved verbatim.

Closes #20. Closes #23. Part of epics #19 and #22.

## Why bundled

Epic #22 is a direct follow-up to FR5 of epic #19's PRD (which deferred the double-click decision). Splitting into two PRs would mean rebasing #22 onto a merged #19 with no real review benefit — the change set is small (~150 lines net) and the test suite covers both behaviors together.

## Implementation Notes

### Reveal-only-if-open (#19/#20)
- New helper `isFileOpenInAnyTab(uri)` scans `vscode.window.tabGroups.all[*].tabs[*].input` and matches `vscode.TabInputText` by `uri.fsPath`. Tabs in non-active groups still count as open (preferred over `visibleTextEditors`).
- The gate sits **after** all seven existing validations in the `revealInFile` handler — invalid inputs continue to surface errors identically. Closed-file path logs `skipped: <path> (not open in any tab)` to the output channel.
- `test/runTests.ts` passes `test-fixtures/` as the launch workspace folder so project-shared paths land in `buildKnownConfigPaths()`.

### Double-click-opens-file (#22/#23)
- VS Code `TreeView` has no native double-click event. Detection is a debounce inside the bound `claudeConfig.revealInFile` command: track `lastClick: { nodeId, time }` in module state; if a second activation lands on the same node within `DOUBLE_CLICK_THRESHOLD_MS` (300 ms), call `openAndPositionAtKey` even when the file is closed.
- Single-click is unaffected — the existing reveal-only-if-open path runs first, every time. The open-and-position branch fires only on the qualifying second click. Zero added latency on the first click.
- Plumbs a stable `nodeId` (`computeId(ctx)`) through `computeCommand` as a third positional argument. All 9 call sites updated. Command id stays `claudeConfig.revealInFile`; old-shaped callers (no nodeId) still work, just lose dbl-click detection.
- When `workbench.list.openMode === 'doubleClick'`, native VS Code already fires the command exactly once on a real double-click — the handler treats every fire in that mode as the explicit-open intent.
- A hidden `claudeConfig._test_resetDoubleClickState` command lets the test suite reset module state across cases without sharing a module instance — necessary because the registered command runs from bundled `dist/extension.js` while the test imports from `src/`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run test` — 140 passing (4 new in `openFileCommands.test.ts` covering: same-node-within-window opens, same-node-outside-window stays silent, different-node-within-window stays silent, single-fire-in-doubleClick-mode opens — plus 4 existing reveal-only-if-open cases still green)
- [x] Manual verification in Extension Development Host:
  - [x] Click 5+ tree items with no config files open → zero new tabs, no errors
  - [x] Open one config file, click a matching tree item → reveal + range highlight works
  - [x] Right-click → "Open File" still opens unconditionally
  - [x] Double-click a leaf with file closed → file opens, cursor lands at matching JSON key